### PR TITLE
Update useOneInchQuote.ts

### DIFF
--- a/src/hooks/plugins/useOneInch/useOneInchQuote.ts
+++ b/src/hooks/plugins/useOneInch/useOneInchQuote.ts
@@ -12,30 +12,27 @@ export interface UseOneInchQuoteParams {
 }
 export interface UseOneInchQuoteOptions extends UseResolveCallOptions {}
 
-export const useOneInchQuote = (
-  params: UseOneInchQuoteParams,
-  options: UseOneInchQuoteOptions = {},
-) => {
+export const useOneInchQuote = (params: UseOneInchQuoteParams, options: UseOneInchQuoteOptions = {}) => {
   const { Moralis } = useMoralis();
 
   const { fetch, data, isFetching, isLoading, error } = _useResolvePluginCall(
     Plugin.ONE_INCH,
     Moralis.Plugins?.oneInch?.quote,
     null,
-    {
-      chain: params.chain ?? DEFAULT_API_CHAIN,
-      // The token you want to swap
-      fromTokenAddress: params.fromToken.address,
-      // The token you want to receive
-      toTokenAddress: params.toToken.address,
-      amount: Moralis.Units.Token(
-        params.fromAmount,
-        params.fromToken.decimals,
-      ).toString(),
-    },
+    Object.keys(params)?.length
+      ? {
+          chain: params.chain ?? DEFAULT_API_CHAIN,
+          // The token you want to swap
+          fromTokenAddress: params.fromToken.address,
+          // The token you want to receive
+          toTokenAddress: params.toToken.address,
+          amount: Moralis.Units.Token(params.fromAmount, params.fromToken.decimals).toString(),
+        }
+      : null,
     options,
-    false,
+    false
   );
 
   return { getQuote: fetch, data, isFetching, isLoading, error };
 };
+

--- a/src/hooks/plugins/useOneInch/useOneInchQuote.ts
+++ b/src/hooks/plugins/useOneInch/useOneInchQuote.ts
@@ -28,7 +28,7 @@ export const useOneInchQuote = (params: UseOneInchQuoteParams, options: UseOneIn
           toTokenAddress: params.toToken.address,
           amount: Moralis.Units.Token(params.fromAmount, params.fromToken.decimals).toString(),
         }
-      : null,
+      : undefined,
     options,
     false
   );


### PR DESCRIPTION
---
name: "Pull request"
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/react-moralis/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/react-moralis/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Since we are referring to the `params` object keys, we cannot make it optional

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->

Check if the `params` object has no keys we paste it as undefined and we can fetch quote then manually
