### PR TITLE
fixed typo in RaribleNetwork type

### DIFF
--- a/src/hooks/plugins/useRarible/types.ts
+++ b/src/hooks/plugins/useRarible/types.ts
@@ -1,4 +1,4 @@
-export type RaribleNetwork = "rinkiby" | "eth";
+export type RaribleNetwork = "rinkeby" | "eth";
 export type RaribleTokenType = "ERC721" | "ERC1155";
 export type RaribleTokenTypeAssetClass =
   | "ETH"


### PR DESCRIPTION
---
name: "Pull request to fix a typo in RaribleNetwork type"
about: just a simple typo fix
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [ x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/react-moralis/blob/main/SECURITY.md).
- [ x] My code is conform the [code style](https://github.com/MoralisWeb3/react-moralis/blob/main/CODE_STYLE.md)
- [ x] I have made corresponding changes to the documentation
- [ x] I have updated Typescript definitions when needed

### Issue Description

There is typo in RaribleNetwork type definition -> 'rinkiby'

Related issue: #`FILL_THIS_OUT`

### Solution Description

Correct from 'rinkiby' -> 'rinkeby'.  So ts will suggest the right value and the autocomplete will not introduce error in useRarible hook.
