### PR TITLE
fix: moralis-v1 imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "husky": "^7.0.4",
     "jest": "^27.4.5",
     "lint-staged": "^12.1.2",
-    "moralis": "1.8.0",
+    "moralis-v1": "^1.11.0",
     "prettier": "^2.5.1",
     "rollup": "^2.61.1",
     "rollup-plugin-cleaner": "^1.0.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-import { components } from "moralis/types/generated/web3Api";
+import { components } from "moralis-v1/types/generated/web3Api";
 export type ApiChain = components["schemas"]["chainList"];
 
 export const DEFAULT_API_CHAIN: ApiChain = "eth";

--- a/src/context/MoralisContext/MoralisContext.ts
+++ b/src/context/MoralisContext/MoralisContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import {
   AuthenticateOptions,
   Authentication,

--- a/src/hooks/core/useMoralis/_useMoralisAuth.ts
+++ b/src/hooks/core/useMoralis/_useMoralisAuth.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { setMultipleDataToUser, SetUserData } from "./utils/setUserData";
 import { AuthError } from "../../../context/MoralisContext/MoralisContext";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { Environment } from "./_useMoralisInit";
 
 export enum AuthenticationState {

--- a/src/hooks/core/useMoralis/_useMoralisInit.ts
+++ b/src/hooks/core/useMoralis/_useMoralisInit.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import MoralisImport from "moralis";
+import MoralisImport from "moralis-v1";
 import { ReactMoralisError } from "../../../Errors";
 
 export type Environment = "browser" | "native";

--- a/src/hooks/core/useMoralis/_useMoralisUser.ts
+++ b/src/hooks/core/useMoralis/_useMoralisUser.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useCallback, useState } from "react";
 import { NotAuthenticatedError, ReactMoralisError } from "../../../Errors";
 import { setMultipleDataToUser, SetUserData } from "./utils/setUserData";

--- a/src/hooks/core/useMoralis/_useMoralisWeb3.ts
+++ b/src/hooks/core/useMoralis/_useMoralisWeb3.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 
 export type Web3EnableOptions = MoralisType.EnableOptions & {
   onError?: (error: Error) => void;

--- a/src/hooks/core/useMoralis/utils/setUserData.ts
+++ b/src/hooks/core/useMoralis/utils/setUserData.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { ValidationError } from "../../../../Errors";
 
 // UserData can accept all these types

--- a/src/hooks/core/useMoralisFile/useMoralisFile.ts
+++ b/src/hooks/core/useMoralisFile/useMoralisFile.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useCallback, useState } from "react";
 import { useMoralis } from "../useMoralis";
 

--- a/src/hooks/core/useMoralisObject/useNewMoralisObject.ts
+++ b/src/hooks/core/useMoralisObject/useNewMoralisObject.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useCallback, useState } from "react";
 import { useMoralis } from "../useMoralis";
 

--- a/src/hooks/core/useMoralisQuery/_useSafeUpdatedQuery.ts
+++ b/src/hooks/core/useMoralisQuery/_useSafeUpdatedQuery.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useMemo } from "react";
 import { useMoralis } from "../useMoralis";
 import { Query } from "../../../utils/genericQuery";

--- a/src/hooks/core/useMoralisQuery/useMoralisQuery.ts
+++ b/src/hooks/core/useMoralisQuery/useMoralisQuery.ts
@@ -1,5 +1,5 @@
 import { WritableDraft } from "immer/dist/internal";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useCallback } from "react";
 import { DefaultQueryAttribute, Query } from "../../../utils/genericQuery";
 import { useMoralis } from "../useMoralis";

--- a/src/hooks/core/useMoralisSubscription/_useMoralisSubscriptionListener.ts
+++ b/src/hooks/core/useMoralisSubscription/_useMoralisSubscriptionListener.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useEffect } from "react";
 import { useMoralis } from "../useMoralis";
 

--- a/src/hooks/core/useMoralisSubscription/useMoralisSubscription.ts
+++ b/src/hooks/core/useMoralisSubscription/useMoralisSubscription.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useContext, useEffect, useRef, useState } from "react";
 import { MoralisContext } from "../../../context";
 import { Query } from "../../../utils/genericQuery";

--- a/src/hooks/web3ApiWrappers/useApiContract/useApiContract.ts
+++ b/src/hooks/web3ApiWrappers/useApiContract/useApiContract.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis/types";
+import MoralisType from "moralis-v1/types";
 import {
   useMoralisWeb3Api,
   useMoralisWeb3ApiCall,

--- a/src/hooks/web3ApiWrappers/useERC20Balances/useERC20Balances.ts
+++ b/src/hooks/web3ApiWrappers/useERC20Balances/useERC20Balances.ts
@@ -5,7 +5,7 @@ import {
   UseMoralisWeb3ApiCallOptions,
 } from "../../core/useMoralisWeb3Api";
 import { DEFAULT_API_CHAIN } from "../../../config";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { isValidApiChain } from "../../../utils/isValidApiChain";
 
 export interface UseERC20BalancesParams

--- a/src/hooks/web3ApiWrappers/useERC20Transfers/useERC20Transfers.ts
+++ b/src/hooks/web3ApiWrappers/useERC20Transfers/useERC20Transfers.ts
@@ -6,7 +6,7 @@ import {
   UseMoralisWeb3ApiCallOptions,
 } from "../../core/useMoralisWeb3Api";
 import { DEFAULT_API_CHAIN } from "../../../config";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { isValidApiChain } from "../../../utils/isValidApiChain";
 
 export interface UseERC20TransfersParams

--- a/src/hooks/web3ApiWrappers/useNFTBalances/useNFTBalances.ts
+++ b/src/hooks/web3ApiWrappers/useNFTBalances/useNFTBalances.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useMoralis } from "../../core/useMoralis";
 import {
   useMoralisWeb3Api,

--- a/src/hooks/web3ApiWrappers/useNFTTransfers/useNFTTransfers.ts
+++ b/src/hooks/web3ApiWrappers/useNFTTransfers/useNFTTransfers.ts
@@ -10,7 +10,7 @@ import { isValidApiChain } from "../../../utils/isValidApiChain";
 
 export interface UseNFTTransfersParams
   extends Omit<
-    Parameters<typeof MoralisType.Web3API["account"]["getTokenTransfers"]>[0],
+    Parameters<typeof MoralisType.Web3API["account"]["getNFTTransfers"]>[0],
     "address"
   > {
   address?: string;

--- a/src/hooks/web3ApiWrappers/useNFTTransfers/useNFTTransfers.ts
+++ b/src/hooks/web3ApiWrappers/useNFTTransfers/useNFTTransfers.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useMoralis } from "../../core/useMoralis";
 import {
   useMoralisWeb3Api,

--- a/src/hooks/web3ApiWrappers/useNativeBalance/useNativeBalance.ts
+++ b/src/hooks/web3ApiWrappers/useNativeBalance/useNativeBalance.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis/types";
+import MoralisType from "moralis-v1/types";
 import { useMemo } from "react";
 import { DEFAULT_API_CHAIN } from "../../../config";
 import { isValidApiChain } from "../../../utils/isValidApiChain";

--- a/src/hooks/web3ApiWrappers/useNativeTransactions/useNativeTransactions.ts
+++ b/src/hooks/web3ApiWrappers/useNativeTransactions/useNativeTransactions.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { useMoralis } from "../../core/useMoralis";
 import {
   useMoralisWeb3Api,

--- a/src/hooks/web3ApiWrappers/useTokenPrice/useTokenPrice.ts
+++ b/src/hooks/web3ApiWrappers/useTokenPrice/useTokenPrice.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 import { tokenValueTxt, toUsd } from "../../../utils/formatters";
 import {
   useMoralisWeb3Api,

--- a/src/utils/genericQuery.ts
+++ b/src/utils/genericQuery.ts
@@ -1,4 +1,4 @@
-import MoralisType from "moralis";
+import MoralisType from "moralis-v1";
 
 export type DefaultQueryAttribute = MoralisType.Attributes;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7246,10 +7246,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moralis@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/moralis/-/moralis-1.8.0.tgz#fc0aee2fdccde195e04e9395fa78bac97c1b133f"
-  integrity sha512-p8V5Ur4oLymweySUh+TBuYmQVDeqnNO3+Lk+VfPorGJsmbcer6xVy6MHHNinl1zhhWiCJNpc+XWot5wAcMb4QA==
+moralis-v1@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/moralis-v1/-/moralis-v1-1.11.0.tgz#fc8f5055d14b91c8301337ab58b331fa6e4b4f60"
+  integrity sha512-6FxKTdh1kOLme+R5Z6kIT++MHwZzTrYGhiS/E7hRnapomY423RThrxsnYgs7XnLEe8g2TLvA4Sx0+DIgwYWTjg==
   dependencies:
     "@babel/runtime" "7.16.7"
     "@babel/runtime-corejs3" "7.16.8"


### PR DESCRIPTION
---
name: "fix moralis-v1 imports"
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/react-moralis/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/react-moralis/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->
1. `moralis` imports were not updated after the switch to the `moralis-v1` fork.

2. Type `UseNFTTransfersParams` used in the `useNFTTransfers` hook was incorrect.

### Solution Description

<!-- Add a description of the solution in this PR. -->
1. Updated all imports to the use `moralis-v1`, including the dev dependency.

2. Fixed the `UseNFTTransfersParams` type by changing the property access from `["getTokenTransfers"]` to `["getNFTTransfers"]`
